### PR TITLE
Feature/framework selection refactor

### DIFF
--- a/www/src/frameworks.ts
+++ b/www/src/frameworks.ts
@@ -19,7 +19,7 @@ export const frameworks: {[framework: string]: Framework} = {
     // defaultZoom: 13,
     polygonZoomThreshold: 13,
     defaultQuery: {
-      framework: 'liveng0',
+      tableName: 'liveng0',
       center: {lat: 54, lng: -1.4},
       // center: {lat: 53.7, lng: -0.45},
       indexname: 'NDVI',
@@ -45,7 +45,7 @@ export const frameworks: {[framework: string]: Framework} = {
     bboxPadding: {latPad: 0.02, lngPad: 0.04},
     polygonZoomThreshold: 13,
     defaultQuery: {
-      framework: 'liveng1',
+      tableName: 'liveng1',
       center: {lat: 54, lng: -1.4},
       indexname: 'NDVI',
       statistic: 'mean',
@@ -68,7 +68,7 @@ export const frameworks: {[framework: string]: Framework} = {
     bboxPadding: {latPad: 0.02, lngPad: 0.04},
     polygonZoomThreshold: 13,
     defaultQuery: {
-      framework: 'habmos_cairngorms',
+      tableName: 'habmos_cairngorms',
       center: {lat: 57.1, lng: -3.7},
       indexname: 'NDVI',
       statistic: 'mean',
@@ -91,7 +91,7 @@ export const frameworks: {[framework: string]: Framework} = {
     bboxPadding: {latPad: 0.02, lngPad: 0.04},
     polygonZoomThreshold: 13,
     defaultQuery: {
-      framework: 'spaceint_cairngorms',
+      tableName: 'spaceint_cairngorms',
       center: {lat: 57.1, lng: -3.7},
       indexname: 'NDVI',
       statistic: 'mean',

--- a/www/src/slices/mapper/FrameworkPanel.tsx
+++ b/www/src/slices/mapper/FrameworkPanel.tsx
@@ -18,7 +18,7 @@ export let FrameworkPanel = () => {
         <div className="leading-tight">            
           <select
             name="frameworkname" id="frameworkname-select"
-            defaultValue={currentFramework.defaultQuery.framework}
+            defaultValue={currentFramework.defaultQuery.tableName}
             onChange={e => dispatch(mapperActions.alterQueryFramework(e.target.value))}
             className="bg-white hover:bg-gray-200 p-0.5"
             >
@@ -28,7 +28,7 @@ export let FrameworkPanel = () => {
           </select>
 
           <div className="flex gap-2 items-center ml-1.5">
-            <div className="little-label-text ">{currentFramework.defaultQuery.framework}</div>
+            <div className="little-label-text ">{currentFramework.defaultQuery.tableName}</div>
             <svg xmlns="http://www.w3.org/2000/svg" className="h-1 w-7 " stroke="#ff7800">
               <line x1="0" y1="3" x2="60" y2="3" strokeWidth="3" strokeDasharray="5 5" strokeLinecap="round" strokeLinejoin="round" />
             </svg>

--- a/www/src/slices/mapper/FrameworkPanel.tsx
+++ b/www/src/slices/mapper/FrameworkPanel.tsx
@@ -9,7 +9,7 @@ import { Panel } from './Panel'
 
 export let FrameworkPanel = () => {
   let dispatch = useStateDispatcher()
-  let query = useStateSelector(s => s.mapper.query)
+  let currentFramework = useStateSelector(s => s.mapper.currentFramework)
 
   return (
     <Panel extraClasses="absolute bottom-4 left-6 min-w-[14rem] pl-4 pr-6 py-2 my-1">
@@ -18,7 +18,7 @@ export let FrameworkPanel = () => {
         <div className="leading-tight">            
           <select
             name="frameworkname" id="frameworkname-select"
-            defaultValue={query.framework}
+            defaultValue={currentFramework.defaultQuery.framework}
             onChange={e => dispatch(mapperActions.alterQueryFramework(e.target.value))}
             className="bg-white hover:bg-gray-200 p-0.5"
             >
@@ -28,7 +28,7 @@ export let FrameworkPanel = () => {
           </select>
 
           <div className="flex gap-2 items-center ml-1.5">
-            <div className="little-label-text ">{frameworks[query.framework].defaultQuery.framework}</div>
+            <div className="little-label-text ">{currentFramework.defaultQuery.framework}</div>
             <svg xmlns="http://www.w3.org/2000/svg" className="h-1 w-7 " stroke="#ff7800">
               <line x1="0" y1="3" x2="60" y2="3" strokeWidth="3" strokeDasharray="5 5" strokeLinecap="round" strokeLinejoin="round" />
             </svg>

--- a/www/src/slices/mapper/LeafletMap.tsx
+++ b/www/src/slices/mapper/LeafletMap.tsx
@@ -3,7 +3,6 @@ import L, { LatLngBounds } from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 
 import { enableMapSet } from 'immer'
-import { frameworks } from '../../frameworks'
 import { FieldData, isChoroplethItem, Poly } from './types'
 import { getChoroplethMaxZValue, getColour } from './helpers/choroplethHelpers'
 import { getMarkerColour } from './helpers/fieldDataHelper'
@@ -37,7 +36,7 @@ export let LeafletMap = () => {
   let state = useStateSelector(s => s.mapper)
   let dispatch = useStateDispatcher()
   
-  let framework = frameworks[state.query.framework]
+  let framework = state.currentFramework
 
   let updatePolygonLayers = () => {
     // remove layers for polygons that aren't in state.polygons or not included in current habitat filter
@@ -142,11 +141,11 @@ export let LeafletMap = () => {
   useEffect(() => {
     dispatch(mapperActions.selectPolygon(undefined))
     if (state.panToNewFramework) {
-      leafletMap.setView(frameworks[state.query.framework].defaultQuery.center, state.zoom)  
+      leafletMap.setView(state.currentFramework.defaultQuery.center, state.zoom)  
     }    
     frameworkBoundary.remove()
     frameworkBoundary = L.geoJSON(framework.boundary, { style: frameworkBoundaryStyle }).addTo(leafletMap)
-  }, [state.query.framework])
+  }, [state.currentFramework])
 
   // react to change of `zoom`
   useEffect(() => {
@@ -160,12 +159,12 @@ export let LeafletMap = () => {
       bboxRectangle.remove()
     }
     
-    let bounds = getBoundsOfBboxRectangle(state.query.center, state.query.framework)
+    let bounds = getBoundsOfBboxRectangle(state.query.center, state.currentFramework)
     bboxRectangle = L.rectangle(
       L.latLngBounds(bounds.southWest, bounds.northEast),
       bboxRectangleStyle).addTo(leafletMap)
 
-  }, [state.query.center, state.query.framework])
+  }, [state.query.center, state.currentFramework])
 
   // react to change of habitat ids filter
   // (use polygon and choropleth data already in state to dispplay the relevant habitats in the existing bounding box)

--- a/www/src/slices/mapper/QueryPanel.tsx
+++ b/www/src/slices/mapper/QueryPanel.tsx
@@ -31,7 +31,7 @@ export let QueryPanel = () => {
   }
 
   function getFrameworkHabitatsArray() {
-    let frameworkHabitats = state.frameworkHabitats.get(state.currentFramework)
+    let frameworkHabitats = state.frameworkHabitats.get(state.currentFramework.defaultQuery.tableName)
     if (frameworkHabitats) {
       return frameworkHabitats
     }

--- a/www/src/slices/mapper/QueryPanel.tsx
+++ b/www/src/slices/mapper/QueryPanel.tsx
@@ -20,7 +20,7 @@ export let QueryPanel = () => {
   let dispatch = useStateDispatcher()
   let state = useStateSelector(s => s.mapper)
 
-  let indices = frameworks[state.query.framework].availableIndices
+  let indices = state.currentFramework.availableIndices
 
   function toggleSelectedHabitat (habitatid: number) {
     dispatch(mapperActions.toggleSelectedHabitat(habitatid))
@@ -31,7 +31,7 @@ export let QueryPanel = () => {
   }
 
   function getFrameworkHabitatsArray() {
-    let frameworkHabitats = state.frameworkHabitats.get(frameworks[state.query.framework])
+    let frameworkHabitats = state.frameworkHabitats.get(state.currentFramework)
     if (frameworkHabitats) {
       return frameworkHabitats
     }

--- a/www/src/slices/mapper/ThumbnailSlider.tsx
+++ b/www/src/slices/mapper/ThumbnailSlider.tsx
@@ -5,7 +5,6 @@ import { Poly, SimpleDate } from './types'
 import { Thumb } from './Thumbnail'
 import { getPolygonOutline, getReprojectedCoordinates } from '../../thumbnails/thumbnailGenerator'
 import { height, width } from './helpers/thumbnailHelper'
-import { frameworks } from '../../frameworks'
 import { useStateDispatcher, useStateSelector } from '../../state/hooks'
 import { Toggle } from '../../components/Toggle'
 import { mapperActions } from './slice'
@@ -14,7 +13,7 @@ import { indexnames } from './helpers/statsHelper'
 export let ThumbnailSlider = (props: {framesWithDate: {frame: string, date: SimpleDate}[]}) => {
 
   let dispatch = useStateDispatcher()
-  let framework = useStateSelector(s => s.mapper.query.framework)
+  let framework = useStateSelector(s => s.mapper.currentFramework)
   let selectedPolygon = useStateSelector(s => s.mapper.selectedPolygon) as Poly // selectedPolygon can't be undefined in this component
   let showOutlines = useStateSelector(s => s.mapper.showOutlines)
   let useProxy = useStateSelector(s => s.mapper.useProxy)
@@ -22,8 +21,8 @@ export let ThumbnailSlider = (props: {framesWithDate: {frame: string, date: Simp
   let indexname = useStateSelector(s => s.mapper.query.indexname)
   
   // do calcs common to all the thumbnails up here in the slider
-  let nativeCoords = useMemo(() => getReprojectedCoordinates(selectedPolygon.geojson.coordinates, frameworks[framework].srs),
-                                                            [selectedPolygon.geojson.coordinates, frameworks[framework].srs])
+  let nativeCoords = useMemo(() => getReprojectedCoordinates(selectedPolygon.geojson.coordinates, framework.srs),
+                                                            [selectedPolygon.geojson.coordinates, framework.srs])
   let polygonRings = useMemo(() => getPolygonOutline(nativeCoords, width, height),
                                                     [nativeCoords, width, height])
   let outline = <svg

--- a/www/src/slices/mapper/api.ts
+++ b/www/src/slices/mapper/api.ts
@@ -17,7 +17,7 @@ export let fetchPolygons = (query: RootState['mapper']['query'], currentFramewor
   let getParamsForFetchPolygons = (query: RootState['mapper']['query']): PolygonsQuery => {
     let bounds = getBoundsOfBboxRectangle(query.center, currentFramework)
     return {
-      framework: currentFramework.defaultQuery.framework,
+      framework: currentFramework.defaultQuery.tableName,
       bbox: bboxToWkt(getBboxFromBounds(bounds)),
       limit: 3001
     }
@@ -46,11 +46,23 @@ let makeCacheKey = (polyid: string, params: ChoroplethKeyParams) => {
   return `${Object.values(keyParams).join(':')}::${polyid}`
 }
 
+let makeCacheKeyFromState = (polyid: string, state: RootState['mapper']) => {
+  let keyParams = {
+    framework:            state.currentFramework.defaultQuery.tableName, 
+    indexname:            state.query.indexname,
+    yearFrom:             state.query.yearFrom,
+    monthFrom:            state.query.monthFrom,
+    yearTo:               state.query.yearTo,
+    monthTo:              state.query.monthTo,
+  }  
+  return `${Object.values(keyParams).join(':')}::${polyid}`
+}
+
 export let fetchChoropleth = (state: RootState['mapper']): Observable<ChoroplethQueryResult> => {
 
   let cached = state.polygons.polys
     .map(p => {
-      let key = makeCacheKey(p.polyid, state.query)
+      let key = makeCacheKeyFromState(p.polyid, state)
       return choroplethCache.get(key)
     })
     .filter(item => item !== undefined) as (ChoroplethItem | ChoroplethNone)[]
@@ -58,7 +70,7 @@ export let fetchChoropleth = (state: RootState['mapper']): Observable<Choropleth
   let needed = state.polygons.polys.filter(p => !cached.find(c => c.polyid === p.polyid))
 
   let params: ChoroplethParams = {
-    framework:            state.currentFramework.defaultQuery.framework, 
+    framework:            state.currentFramework.defaultQuery.tableName, 
     indexname:            state.query.indexname,
     yearFrom:             state.query.yearFrom,
     monthFrom:            state.query.monthFrom,
@@ -103,7 +115,7 @@ if (!state.selectedPolygon)
   throw 'Shouldn\'t get here - no polygon selected'
 
   let params = {
-    framework:      state.currentFramework.defaultQuery.framework,
+    framework:      state.currentFramework.defaultQuery.tableName,
     indexname:      state.query.indexname,
     polyids:        [state.selectedPolygon.polyid],
     polyPartitions: [state.selectedPolygon.partition],
@@ -133,7 +145,7 @@ export let fetchFieldData = (query: RootState['mapper']['query'], currentFramewo
   let bounds = getBoundsOfBboxRectangle(query.center, currentFramework)
 
   let params = {
-    framework: currentFramework.defaultQuery.framework,
+    framework: currentFramework.defaultQuery.tableName,
     bbox: bboxToWkt(getBboxFromBounds(bounds))
   }
 
@@ -149,7 +161,7 @@ export let fetchHabitats = (requiredFramework: Framework): Observable<FrameworkH
 
   let getParamsForFetchHabitats = (requiredFramework: Framework): HabitatsQuery => {
     return {
-      framework: requiredFramework.defaultQuery.framework,
+      framework: requiredFramework.defaultQuery.tableName,
     }
   }
   

--- a/www/src/slices/mapper/api.ts
+++ b/www/src/slices/mapper/api.ts
@@ -23,7 +23,7 @@ export let fetchPolygons = (query: RootState['mapper']['query'], currentFramewor
     }
   }
 
-  let keyParams = { framework: currentFramework }
+  let keyParams = { framework: currentFramework.defaultQuery.tableName }
   
   // todo: we could also cache the polygons...
   return api('polygons', getParamsForFetchPolygons(query)).pipe(

--- a/www/src/slices/mapper/epics.ts
+++ b/www/src/slices/mapper/epics.ts
@@ -19,7 +19,7 @@ let fetchPolygonsEpic = (action$: any, state$: StateObservable<RootState>) => ac
   switchMap(() =>
     concat(
       of(globalActions.startLoading('polygons')),
-      fetchPolygons(state$.value.mapper.query).pipe(
+      fetchPolygons(state$.value.mapper.query, state$.value.mapper.currentFramework).pipe(
         map(result => mapperActions.fetchPolygonsCompleted(result)),
         catchError(e => of(globalActions.errorOccurred(e.message)))),
       of(globalActions.stopLoading('polygons')),

--- a/www/src/slices/mapper/helpers/bboxHelpers.ts
+++ b/www/src/slices/mapper/helpers/bboxHelpers.ts
@@ -1,7 +1,8 @@
 import { frameworks } from '../../../frameworks'
+import { Framework } from '../types'
 
-export let getBoundsOfBboxRectangle = (center: { lat: number, lng: number }, framework: string) => {
-  let padding = frameworks[framework].bboxPadding
+export let getBoundsOfBboxRectangle = (center: { lat: number, lng: number }, currentFramework: Framework) => {
+  let padding = currentFramework.bboxPadding
   return {
     southWest: { lat: center.lat - padding.latPad, lng: center.lng - padding.lngPad },
     northEast: { lat: center.lat + padding.latPad, lng: center.lng + padding.lngPad },

--- a/www/src/slices/mapper/slice.ts
+++ b/www/src/slices/mapper/slice.ts
@@ -20,7 +20,7 @@ let slice = createSlice({
     panToNewFramework: true,
     query: defaultQuery,
     polygons:   { polys: [] as Poly[], params: { framework: defaultFramework } },
-    choropleth: { items: [] as (ChoroplethItem | ChoroplethNone)[], params: {framework: defaultQuery.framework, indexname: defaultQuery.indexname } },
+    choropleth: { items: [] as (ChoroplethItem | ChoroplethNone)[], params: {framework: defaultQuery.tableName, indexname: defaultQuery.indexname } },
     fieldData: [] as FieldData[],
     selectedPolygon: undefined as Poly | undefined,
     previousSelectedPolygon: undefined as Poly | undefined,

--- a/www/src/slices/mapper/slice.ts
+++ b/www/src/slices/mapper/slice.ts
@@ -19,7 +19,7 @@ let slice = createSlice({
     zoomedEnoughToShowPolygons: false,
     panToNewFramework: true,
     query: defaultQuery,
-    polygons:   { polys: [] as Poly[], params: { framework: defaultFramework } },
+    polygons:   { polys: [] as Poly[], params: { framework: defaultQuery.tableName } },
     choropleth: { items: [] as (ChoroplethItem | ChoroplethNone)[], params: {framework: defaultQuery.tableName, indexname: defaultQuery.indexname } },
     fieldData: [] as FieldData[],
     selectedPolygon: undefined as Poly | undefined,
@@ -30,7 +30,7 @@ let slice = createSlice({
     showOutlines: true,
     useProxy: true,
     thumbType: 'index' as 'colour' | 'index',
-    frameworkHabitats: new Map<Framework, Habitat[]>(),
+    frameworkHabitats: new Map<String, Habitat[]>(),
   },
   reducers: {
     initialise: () => {
@@ -100,7 +100,7 @@ let slice = createSlice({
       state.fieldData = a.payload.fieldData
     },
     fetchHabitatsCompleted: (state, a: PayloadAction<FrameworkHabitats>) => {
-      state.frameworkHabitats.set(a.payload.framework, a.payload.habitats)
+      state.frameworkHabitats.set(a.payload.framework.defaultQuery.tableName, a.payload.habitats)
     },
     selectPolygon: (state, a: PayloadAction<Poly | undefined>) => {
       // the new value is `undefined` if deselecting
@@ -149,7 +149,7 @@ let slice = createSlice({
     toggleSelectAllHabitats: (state, a: PayloadAction<boolean>) => {
       if (a.payload) {
         const allFrameworkHabitatIds = 
-          state.frameworkHabitats.get(state.currentFramework)?.map((x: Habitat) => {return x.id})
+          state.frameworkHabitats.get(state.currentFramework.defaultQuery.tableName)?.map((x: Habitat) => {return x.id})
         state.query.habitatids = allFrameworkHabitatIds ? allFrameworkHabitatIds : []  
       } else {
         state.query.habitatids = []

--- a/www/src/slices/mapper/slice.ts
+++ b/www/src/slices/mapper/slice.ts
@@ -12,13 +12,14 @@ let defaultQuery = defaultFramework.defaultQuery
 let slice = createSlice({
   name: 'mapper',
   initialState: {
+    currentFramework: defaultFramework as Framework,
     showPolygons: true,
     showNpmsData: false,
     zoom: defaultFramework.defaultZoom,
     zoomedEnoughToShowPolygons: false,
     panToNewFramework: true,
     query: defaultQuery,
-    polygons:   { polys: [] as Poly[], params: { framework: defaultQuery.framework } },
+    polygons:   { polys: [] as Poly[], params: { framework: defaultFramework } },
     choropleth: { items: [] as (ChoroplethItem | ChoroplethNone)[], params: {framework: defaultQuery.framework, indexname: defaultQuery.indexname } },
     fieldData: [] as FieldData[],
     selectedPolygon: undefined as Poly | undefined,
@@ -42,25 +43,25 @@ let slice = createSlice({
       state.showNpmsData = !state.showNpmsData
     },
     mapZoomIn: (state) => {
-      if (state.zoom < frameworks[state.query.framework].maxZoom) {
+      if (state.zoom < state.currentFramework.maxZoom) {
         state.zoom++
       }
     },
     mapZoomOut: (state) => {
-      if (state.zoom > frameworks[state.query.framework].minZoom) {
+      if (state.zoom > state.currentFramework.minZoom) {
         state.zoom--
       }
     },
     mapZoomChanged: (state, a: PayloadAction<number>) => {
       state.zoom = a.payload
-      state.zoomedEnoughToShowPolygons = state.zoom >= frameworks[state.query.framework].polygonZoomThreshold
+      state.zoomedEnoughToShowPolygons = state.zoom >= state.currentFramework.polygonZoomThreshold
       state.panToNewFramework = state.zoom === defaultFramework.defaultZoom
     },
     mapCenterChanged: (state, a: PayloadAction<{ lat: number, lng: number }>) => {
       state.query.center = a.payload
     },
     alterQueryFramework: (state, a: PayloadAction<string>) => {
-      state.query.framework = a.payload
+      state.currentFramework = frameworks[a.payload]
       state.query.habitatids = []
     },
     alterQueryIndexname: (state, a: PayloadAction<Indexname>) => {
@@ -148,7 +149,7 @@ let slice = createSlice({
     toggleSelectAllHabitats: (state, a: PayloadAction<boolean>) => {
       if (a.payload) {
         const allFrameworkHabitatIds = 
-          state.frameworkHabitats.get(frameworks[state.query.framework])?.map((x: Habitat) => {return x.id})
+          state.frameworkHabitats.get(state.currentFramework)?.map((x: Habitat) => {return x.id})
         state.query.habitatids = allFrameworkHabitatIds ? allFrameworkHabitatIds : []  
       } else {
         state.query.habitatids = []

--- a/www/src/slices/mapper/types.ts
+++ b/www/src/slices/mapper/types.ts
@@ -13,7 +13,7 @@ export type Framework = {
   minZoom: number
   polygonZoomThreshold: number
   defaultQuery: {
-    framework: string
+    tableName: string
     center: {lat: number, lng: number}
     indexname: Indexname
     statistic: Statistic
@@ -28,9 +28,8 @@ export type Framework = {
 
 export type Query = Framework['defaultQuery']
 
-export type PolygonsQuery = Pick<Query,
-  | 'framework'
-> & {
+export type PolygonsQuery = {
+  framework: string
   bbox: string
   limit: number
 }
@@ -58,15 +57,14 @@ export type PolygonsQueryResult = {
   params: { framework: Framework }
 }
 
-export type FieldDataQuery = Pick<Query,
-  | 'framework'
-> & {
+export type FieldDataQuery = {
+  framework: string
   bbox: string
 }
 
-export type HabitatsQuery = Pick<Query,
-  | 'framework'
->
+export type HabitatsQuery = {
+  framework: string
+}
 
 export type FieldData = {
   sampleid: string,
@@ -90,13 +88,14 @@ export type FieldDataQueryResult = {
 }
 
 export type ChoroplethKeyParams = Pick<Query,
-  | 'framework'
   | 'indexname'
   | 'yearFrom'
   | 'monthFrom'
   | 'yearTo'
   | 'monthTo'
->
+> & {
+  framework: string
+}
 
 export type ChoroplethParams = ChoroplethKeyParams & {
   polyids: string[],

--- a/www/src/slices/mapper/types.ts
+++ b/www/src/slices/mapper/types.ts
@@ -54,7 +54,7 @@ export type Poly = {
 
 export type PolygonsQueryResult = {
   polys:  Poly[]
-  params: { framework: Framework }
+  params: { framework: string}
 }
 
 export type FieldDataQuery = {

--- a/www/src/slices/mapper/types.ts
+++ b/www/src/slices/mapper/types.ts
@@ -55,7 +55,7 @@ export type Poly = {
 
 export type PolygonsQueryResult = {
   polys:  Poly[]
-  params: { framework: string }
+  params: { framework: Framework }
 }
 
 export type FieldDataQuery = Pick<Query,


### PR DESCRIPTION
Allows opaque code such as 

```frameworks[state.query.framework].defaultQuery.framework```

to be written as

```state.currentFramework.defaultQuery.tableName```